### PR TITLE
do not create cert if rule auto ssl  config not provide.

### DIFF
--- a/cmd/certcontroller/main.go
+++ b/cmd/certcontroller/main.go
@@ -44,6 +44,10 @@ func main() {
 
 	for _, gwRule := range gwRules {
 		if gwRule.AutoSsl == true {
+			if gwRule.AutoSslConfig == "" {
+				logrus.Warningf("domain %s open auto ssl but not provider config ", gwRule.DomainName)
+				continue
+			}
 			var needRequestCert bool
 			var existCert *rainbond.CertificatesR
 			teamCertInfo, ok := allTeamCertInfo[gwRule.TeamName]


### PR DESCRIPTION
If the user turns AutoSSL on but does not select the authentication configuration, the controller continuously alarms.